### PR TITLE
Minor GUI changes

### DIFF
--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -2,7 +2,7 @@
 import LeftArrow from '@fortawesome/fontawesome-free/svgs/solid/arrow-circle-left.svg'
 // @ts-expect-error TS(2307) FIXME: Cannot find module '@fortawesome/fontawesome-free/... Remove this comment to see the full error message
 import RightArrow from '@fortawesome/fontawesome-free/svgs/solid/arrow-circle-right.svg'
-import React, { useState, Dispatch, SetStateAction } from 'react'
+import React, { useState } from 'react' // , Dispatch, SetStateAction
 import styled from 'styled-components'
 
 // @ts-expect-error TS(7016) FIXME: Could not find a declaration file for module '@gno... Remove this comment to see the full error message
@@ -23,15 +23,16 @@ import {
   hasCopyNumberVariants,
   isV2,
 } from '@gnomad/dataset-metadata/metadata'
-import ConstraintTable from '../ConstraintTable/ConstraintTable'
-import VariantCooccurrenceCountsTable, {
+// import ConstraintTable from '../ConstraintTable/ConstraintTable'
+// import VariantCooccurrenceCountsTable, 
+import {
   HeterozygousVariantCooccurrenceCountsPerSeverityAndAf,
   HomozygousVariantCooccurrenceCountsPerSeverityAndAf,
 } from './VariantCooccurrenceCountsTable'
 
 import DocumentTitle from '../DocumentTitle'
 import GnomadPageHeading from '../GnomadPageHeading'
-import InfoButton from '../help/InfoButton'
+// import InfoButton from '../help/InfoButton'
 import Link from '../Link'
 import RegionalConstraintTrack from '../RegionalConstraintTrack'
 import RegionalMissenseConstraintTrack, {
@@ -70,7 +71,7 @@ import {
   CheckboxInput,
   LegendSwatch,
 } from '../ChartStyles'
-import { logButtonClick } from '../analytics'
+// import { logButtonClick } from '../analytics'
 import { GtexTissueExpression } from './TranscriptsTissueExpression'
 
 export type Strand = '+' | '-'
@@ -176,48 +177,48 @@ const GeneInfoColumn = styled.div`
   }
 `
 
-const ConstraintOrCooccurrenceColumn = styled.div`
-  width: 55%;
+// const ConstraintOrCooccurrenceColumn = styled.div`
+//   width: 55%;
 
-  @media (max-width: 1200px) {
-    width: 100%;
-  }
-`
+//   @media (max-width: 1200px) {
+//     width: 100%;
+//   }
+// `
 
-type TableName = 'constraint' | 'cooccurrence'
+// type TableName = 'constraint' | 'cooccurrence'
 
-type TableSelectorProps = {
-  ownTableName: TableName
-  selectedTableName: TableName
-  setSelectedTableName: Dispatch<SetStateAction<TableName>>
-}
+// type TableSelectorProps = {
+//   ownTableName: TableName
+//   selectedTableName: TableName
+//   setSelectedTableName: Dispatch<SetStateAction<TableName>>
+// }
 
 // prettier-ignore
-const BaseTableSelector = styled.div<TableSelectorProps>
+// const BaseTableSelector = styled.div<TableSelectorProps>
 
-const TableSelector = BaseTableSelector.attrs(
-  ({ setSelectedTableName, ownTableName }: TableSelectorProps) => ({
-    onClick: () => {
-      if (ownTableName === 'cooccurrence') {
-        logButtonClick('User selected variant co-occurrence table on Gene page')
-      }
-      setSelectedTableName(ownTableName)
-    },
-  })
-)`
-  border: 1px solid black;
-  border-radius: 0.5em;
-  cursor: pointer;
-  margin-right: 0.5em;
-  padding: 0.25em;
+// const TableSelector = BaseTableSelector.attrs(
+//   ({ setSelectedTableName, ownTableName }: TableSelectorProps) => ({
+//     onClick: () => {
+//       if (ownTableName === 'cooccurrence') {
+//         logButtonClick('User selected variant co-occurrence table on Gene page')
+//       }
+//       setSelectedTableName(ownTableName)
+//     },
+//   })
+// )`
+//   border: 1px solid black;
+//   border-radius: 0.5em;
+//   cursor: pointer;
+//   margin-right: 0.5em;
+//   padding: 0.25em;
 
-  background-color: ${({ ownTableName, selectedTableName }: TableSelectorProps) =>
-    ownTableName === selectedTableName ? '#cbd3da' : 'transparent'};
-`
+//   background-color: ${({ ownTableName, selectedTableName }: TableSelectorProps) =>
+//     ownTableName === selectedTableName ? '#cbd3da' : 'transparent'};
+// `
 
-const TableSelectorWrapper = styled.div`
-  display: flex;
-`
+// const TableSelectorWrapper = styled.div`
+//   display: flex;
+// `
 
 const TrackWrapper = styled.div`
   margin-bottom: 1em;
@@ -277,7 +278,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
   const [includeNonCodingTranscripts, setIncludeNonCodingTranscripts] = useState(!hasCDS)
   const [includeUTRs, setIncludeUTRs] = useState(false)
   const [showTranscripts, setShowTranscripts] = useState(false)
-  const [selectedTableName, setSelectedTableName] = useState<TableName>('constraint')
+  // const [selectedTableName, setSelectedTableName] = useState<TableName>('constraint')
 
   const { width: windowWidth } = useWindowSize()
   const isSmallScreen = windowWidth < 900
@@ -349,7 +350,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
               </p>
             )}
           </GeneInfoColumn>
-          {/*<ConstraintOrCooccurrenceColumn>
+          {/* <ConstraintOrCooccurrenceColumn>
             <TableSelectorWrapper>
               <TableSelector
                 selectedTableName={selectedTableName}
@@ -379,7 +380,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
                 }
               />
             )}
-          </ConstraintOrCooccurrenceColumn>*/}
+          </ConstraintOrCooccurrenceColumn> */}
         </GeneInfoColumnWrapper>
       </TrackPageSection>
       <RegionViewer
@@ -560,7 +561,6 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
         )}
 
         {/* eslint-disable-next-line no-nested-ternary */}
-        
         {hasStructuralVariants(datasetId) ? (
           <StructuralVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
         ) : // eslint-disable-next-line no-nested-ternary

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -349,7 +349,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
               </p>
             )}
           </GeneInfoColumn>
-          <ConstraintOrCooccurrenceColumn>
+          {/*<ConstraintOrCooccurrenceColumn>
             <TableSelectorWrapper>
               <TableSelector
                 selectedTableName={selectedTableName}
@@ -379,7 +379,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
                 }
               />
             )}
-          </ConstraintOrCooccurrenceColumn>
+          </ConstraintOrCooccurrenceColumn>*/}
         </GeneInfoColumnWrapper>
       </TrackPageSection>
       <RegionViewer
@@ -560,6 +560,7 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
         )}
 
         {/* eslint-disable-next-line no-nested-ternary */}
+        
         {hasStructuralVariants(datasetId) ? (
           <StructuralVariantsInGene datasetId={datasetId} gene={gene} zoomRegion={zoomRegion} />
         ) : // eslint-disable-next-line no-nested-ternary

--- a/browser/src/GenePage/GenePage.tsx
+++ b/browser/src/GenePage/GenePage.tsx
@@ -323,12 +323,12 @@ const GenePage = ({ datasetId, gene, geneId }: Props) => {
           selectedDataset={datasetId}
           datasetOptions={{
             includeShortVariants: true,
-            includeStructuralVariants: gene.chrom !== 'M',
-            includeCopyNumberVariants: true,
-            includeExac: gene.chrom !== 'M',
-            includeGnomad2: gene.chrom !== 'M',
-            includeGnomad3: true,
-            includeGnomad3Subsets: gene.chrom !== 'M',
+            includeStructuralVariants: false,
+            includeCopyNumberVariants: false,
+            includeExac: false,
+            includeGnomad2: false,
+            includeGnomad3: false,
+            includeGnomad3Subsets: false,
             includeGnomad4Subsets: true,
           }}
         >

--- a/browser/src/TranscriptPage/TranscriptPage.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.tsx
@@ -140,10 +140,10 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
           datasetOptions={{
             includeShortVariants: true,
             includeStructuralVariants: false,
-            includeExac: transcript.chrom !== 'M',
-            includeGnomad2: transcript.chrom !== 'M',
-            includeGnomad3: true,
-            includeGnomad3Subsets: transcript.chrom !== 'M',
+            includeExac: false,
+            includeGnomad2: false,
+            includeGnomad3: false,
+            includeGnomad3Subsets: false,
             includeGnomad4Subsets: true,
           }}
         >

--- a/browser/src/TranscriptPage/TranscriptPage.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.tsx
@@ -10,12 +10,12 @@ import {
   labelForDataset,
   ReferenceGenome,
 } from '@gnomad/dataset-metadata/metadata'
-import ConstraintTable from '../ConstraintTable/ConstraintTable'
+// import ConstraintTable from '../ConstraintTable/ConstraintTable'
 
 import DocumentTitle from '../DocumentTitle'
 import GeneFlags from '../GenePage/GeneFlags'
 import GnomadPageHeading from '../GnomadPageHeading'
-import InfoButton from '../help/InfoButton'
+// import InfoButton from '../help/InfoButton'
 import RegionViewer from '../RegionViewer/ZoomableRegionViewer'
 import { TrackPage, TrackPageSection } from '../TrackPage'
 import { useWindowSize } from '../windowSize'
@@ -154,10 +154,10 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
             <TranscriptInfo transcript={transcript} />
             <GeneFlags gene={transcript.gene} />
           </div>
-          {/*<div>
+          {/* <div>
             <h2>Constraint {transcript.chrom !== 'M' && <InfoButton topic="constraint" />}</h2>
             <ConstraintTable datasetId={datasetId} geneOrTranscript={transcript} />
-          </div>*/}
+          </div> */}
         </TranscriptInfoColumnWrapper>
       </TrackPageSection>
       <RegionViewer

--- a/browser/src/TranscriptPage/TranscriptPage.tsx
+++ b/browser/src/TranscriptPage/TranscriptPage.tsx
@@ -154,10 +154,10 @@ const TranscriptPage = ({ datasetId, transcript }: Props) => {
             <TranscriptInfo transcript={transcript} />
             <GeneFlags gene={transcript.gene} />
           </div>
-          <div>
+          {/*<div>
             <h2>Constraint {transcript.chrom !== 'M' && <InfoButton topic="constraint" />}</h2>
             <ConstraintTable datasetId={datasetId} geneOrTranscript={transcript} />
-          </div>
+          </div>*/}
         </TranscriptInfoColumnWrapper>
       </TrackPageSection>
       <RegionViewer

--- a/browser/src/VariantList/Variants.tsx
+++ b/browser/src/VariantList/Variants.tsx
@@ -267,7 +267,7 @@ const Variants = ({
   if (variants.length === 0) {
     return (
       <TrackPageSection>
-        <h2 style={{ margin: '2em 0 0.25em' }}>gnomAD variants</h2>
+        <h2 style={{ margin: '2em 0 0.25em' }}>OurDNA variants</h2>
         <p>No gnomAD variants found.</p>
       </TrackPageSection>
     )
@@ -276,7 +276,7 @@ const Variants = ({
   return (
     <div>
       <TrackPageSection>
-        <h2 style={{ margin: '2em 0 0.25em' }}>gnomAD variants</h2>
+        <h2 style={{ margin: '2em 0 0.25em' }}>OurDNA variants</h2>
       </TrackPageSection>
       <Cursor onClick={onNavigatorClick}>
         <VariantTrack

--- a/browser/src/VariantPage/GnomadPopulationsTable.tsx
+++ b/browser/src/VariantPage/GnomadPopulationsTable.tsx
@@ -113,7 +113,7 @@ export class GnomadPopulationsTable extends Component<
     } = this.props
     const { includeExomes, includeGenomes } = this.state
 
-    console.log('Ex & Ge Pops', exomePopulations, genomePopulations)
+    // console.log('Ex & Ge Pops', exomePopulations, genomePopulations)
 
     const mergedPopulations = mergeExomeGenomeAndJointPopulationData({
       datasetId,
@@ -123,14 +123,14 @@ export class GnomadPopulationsTable extends Component<
         includeExomes && includeGenomes && jointPopulations ? jointPopulations : null,
     }).filter((mergedAncestry) => (mergedAncestry.id as string) !== '')
 
-    console.log('MERGED POPULATIONS', mergedPopulations);
+    // console.log('MERGED POPULATIONS', mergedPopulations);
 
     const mergedPopulationsWithNames = addPopulationNames(mergedPopulations)
 
-    console.log('MERGED POPULATIONS WITH NAMES', mergedPopulationsWithNames)
+    // console.log('MERGED POPULATIONS WITH NAMES', mergedPopulationsWithNames)
     const mergedNestedPopulationsWithNames = nestPopulations(mergedPopulationsWithNames)
 
-    console.log('MERGED NESTED POPULATIONS WITH NAMES', mergedNestedPopulationsWithNames)
+    // console.log('MERGED NESTED POPULATIONS WITH NAMES', mergedNestedPopulationsWithNames)
     let populations = mergedNestedPopulationsWithNames
 
     if (hasV2Genome(datasetId) && includeGenomes) {

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -13,7 +13,7 @@ import {
   hasLocalAncestryPopulations,
   isLiftoverSource,
   isLiftoverTarget,
-  usesGrch37,
+  // usesGrch37,
   isV3,
   isV3Subset,
   isV4,

--- a/browser/src/VariantPage/VariantPage.tsx
+++ b/browser/src/VariantPage/VariantPage.tsx
@@ -957,15 +957,18 @@ const VariantPage = ({ datasetId, variantId }: VariantPageProps) => {
               <GnomadPageHeading
                 datasetOptions={{
                   // Include ExAC for GRCh37 datasets
-                  includeExac: usesGrch37(datasetId),
+                  includeExac: false,
                   // Include gnomAD versions based on the same reference genome as the current dataset
-                  includeGnomad2: true,
-                  includeGnomad3: true,
+                  includeGnomad2: false,
+                  includeGnomad3: false,
                   includeGnomad4Subsets: true,
                   // Variant ID not valid for SVs
                   includeStructuralVariants: false,
                   includeCopyNumberVariants: false,
                   urlBuilder: datasetLinkWithLiftover,
+
+                  includeShortVariants: true,
+                  includeGnomad3Subsets: false,
                 }}
                 selectedDataset={datasetId}
                 extra={

--- a/browser/src/VariantPage/VariantTranscriptConsequences.tsx
+++ b/browser/src/VariantPage/VariantTranscriptConsequences.tsx
@@ -28,7 +28,7 @@ const VariantTranscriptConsequences = ({ variant }: Props) => {
 
       <p>
         <Badge level="info">Note</Badge> We will provide this information in a coming minor release.
-        {/*The gene symbols shown below are provided by VEP and may
+        {/* The gene symbols shown below are provided by VEP and may
         differ from the symbol shown on gene pages. */}
       </p>
 

--- a/browser/src/VariantPage/VariantTranscriptConsequences.tsx
+++ b/browser/src/VariantPage/VariantTranscriptConsequences.tsx
@@ -27,8 +27,9 @@ const VariantTranscriptConsequences = ({ variant }: Props) => {
       </p>
 
       <p>
-        <Badge level="info">Note</Badge> The gene symbols shown below are provided by VEP and may
-        differ from the symbol shown on gene pages.
+        <Badge level="info">Note</Badge> We will provide this information in a coming minor release.
+        {/*The gene symbols shown below are provided by VEP and may
+        differ from the symbol shown on gene pages. */}
       </p>
 
       <TranscriptConsequenceList transcriptConsequences={transcriptConsequences} />

--- a/browser/src/variantFeedback.ts
+++ b/browser/src/variantFeedback.ts
@@ -14,5 +14,5 @@ export const variantFeedbackUrl = (variant: any, datasetId: any) => {
     }
     return `${process.env.REPORT_VARIANT_URL}?${queryString.stringify(params)}`
   }
-  return 'mailto:gnomad@broadinstitute.org'
+  return 'mailto:servicedesk@populationgenomics.org.au'
 }

--- a/dataset-metadata/metadata.ts
+++ b/dataset-metadata/metadata.ts
@@ -1032,7 +1032,7 @@ const metadata: Record<DatasetId, DatasetMetadata> = {
     isSubset: true,
     hasConstraints: true,
     hasVariantCoocurrence: false,
-    hasNonCodingConstraints: true,
+    hasNonCodingConstraints: false,
     hasExome: true,
     genesHaveExomeCoverage: true,
     genesHaveGenomeCoverage: true,


### PR DESCRIPTION
This PR is addressing the following requested changes:

**Gene page**

- Dataset dropdown in the top right
- [x] Remove the ‘gnomAD SVs v4.1’ tab entirely
- [x] Options in the dropdown should only be ‘OurDNA v1.0’ for now


- Constraint and variant co-occurrence box / panels
- [x] Drop if possible

- gnomAD variants section
- [x] Replace the “gnomAD variants” title with “OurDNA variants”

**Transcript page**

- Dataset dropdown in the top right
- [x] Options in the dropdown should only be ‘OurDNA v1.0’ for now

- Constraint box
- [x] Drop if possible

- gnomAD variants section
- [x] Replace the “gnomAD variants” title with “OurDNA variants”

**Variant page**

- Dataset dropdown in the top right
- [x] Dropdown isn’t displaying
- [x] Options in the dropdown should only be ‘OurDNA v1.0’ for now


- [x] Replace “Report an issue with this variant” redirect to the OurDNA email not the gnomAD one
- [x] Add a disclaimer to the VEP section to note that we will provide this information in a coming minor release
- [x] Drop the ‘Genomic Constraint of Surrounding 1kb Region’ section