### PR TITLE
Stats page edits - fix legends, add sample counts footer

### DIFF
--- a/browser/src/Legend.tsx
+++ b/browser/src/Legend.tsx
@@ -12,8 +12,8 @@ const LegendWrapper = styled.ul`
 
 const LegendItem = styled.li`
   display: flex;
-  align-items: center;
   flex-shrink: 0;
+  align-items: center;
   margin: 0 1em 0.33em 0;
 `
 

--- a/browser/src/Legend.tsx
+++ b/browser/src/Legend.tsx
@@ -13,8 +13,8 @@ const LegendWrapper = styled.ul`
 const LegendItem = styled.li`
   display: flex;
   align-items: center;
-  margin: 0 1em 0.33em 0;
   flex-shrink: 0;
+  margin: 0 1em 0.33em 0;
 `
 
 type LegendSwatchProps = {

--- a/browser/src/Legend.tsx
+++ b/browser/src/Legend.tsx
@@ -12,7 +12,9 @@ const LegendWrapper = styled.ul`
 
 const LegendItem = styled.li`
   display: flex;
+  align-items: center;
   margin: 0 1em 0.33em 0;
+  flex-shrink: 0;
 `
 
 type LegendSwatchProps = {

--- a/browser/src/StatsPage/StackedBarGraph.tsx
+++ b/browser/src/StatsPage/StackedBarGraph.tsx
@@ -90,7 +90,7 @@ const margin = {
   left: 60,
   right: 10,
   top: 10,
-  legend: 50,
+  legend: 20,
   bar: 25,
 }
 

--- a/browser/src/StatsPage/StatsPage.tsx
+++ b/browser/src/StatsPage/StatsPage.tsx
@@ -63,7 +63,7 @@ const ResponsiveGnomadSamplesContainer = styled.div`
 
 const DiversityBarGraphContainer = styled.div`
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-start;
 
   @media (max-width: 992px) {
     display: block;
@@ -95,7 +95,7 @@ const SexDistributionList = styled.div`
 
 const ResponsiveTable = styled.div`
   display: flex;
-  justify-content: space-around;
+  justify-content: flex-start;
 
   @media (max-width: 992px) {
     display: block;

--- a/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
+++ b/browser/src/StatsPage/StatsPageTables/GeneticAncestryGroupsByVersionTable.tsx
@@ -2,11 +2,14 @@ import React from 'react'
 
 import { DownloadElementAsPNGButton } from '../DownloadFigure'
 
+import Link from '../../Link'
+
 import versionData from './GeneticAncestryGroupsByVersionData.json'
 
 import {
   renderNumberOrDash,
   StatsTable,
+  StatsTableCaption,
   StatsTableHeaderRow,
   StatsTableSubHeaderRow,
   StatsTableBody,
@@ -57,9 +60,15 @@ const GeneticAncestryGroupsByVersionTable = () => {
               )
             })}
         </StatsTableFooter>
-        {/* <StatsTableCaption>
-            <div>* Description here</div>
-            </StatsTableCaption> */}
+        <StatsTableCaption>
+          <div>
+            <p>
+              * Individuals that fall below a 0.8 probability threshold of being assigned to any of
+              the named continent-level ancestry clusters, based on their genetic data. For more
+              details, please see our <Link to="/news">blog posts.</Link>
+            </p>
+          </div>
+        </StatsTableCaption>
       </StatsTable>
       <div>
         <DownloadElementAsPNGButton elementId={elementId} />


### PR DESCRIPTION
This fixes some legend formatting, left-aligns the plots to look a little neater while we only have the one bar for our initial release, and adds a footer to the ancestry groups.