### PR TITLE
Add total SNV and INDEL counts

### DIFF
--- a/browser/src/StatsPage/NumberOfVariantsInOurDNAList.tsx
+++ b/browser/src/StatsPage/NumberOfVariantsInOurDNAList.tsx
@@ -28,8 +28,8 @@ const NumberOfVariantsInOurDNAList = () => {
       <Section>
         <SectionHeader>Short variants</SectionHeader>
         <SectionList>
-          {/* <li>Total SNVs: 786,500,648</li>
-              <li>Total INDELs: 122,583,462</li> */}
+          <li>Total SNVs: 57,322,471</li>
+          <li>Total INDELs: 4,567,608</li>
           <li>
             Variant type* counts
             <SectionList>


### PR DESCRIPTION
Add the total SNV and INDEL counts to the stats page, for all variants that pass all `filters` and `flags` in either the exomes, genomes or both.