### PR TITLE
Fix discrepant_frequencies Ancestry Label - Convert the ancestry code to lowercase.

### DIFF
--- a/browser/src/VariantPage/VariantOccurrenceTable.tsx
+++ b/browser/src/VariantPage/VariantOccurrenceTable.tsx
@@ -74,13 +74,13 @@ const renderGnomadVariantFlag = (variant: Variant, context: VariantContext) => {
   return filters.map((filter) => {
     const data =
       filter === 'discrepant_frequencies'
-        ? {
-            pValue: variant.joint!.freq_comparison_stats.stat_union.p_value,
-            testName: variant.joint!.freq_comparison_stats.stat_union.stat_test_name,
-            geneticAncestry:
-              variant.joint!.freq_comparison_stats.stat_union.gen_ancs[0] || undefined,
-          }
-        : {}
+      ? {
+        pValue: variant.joint!.freq_comparison_stats.stat_union.p_value,
+        testName: variant.joint!.freq_comparison_stats.stat_union.stat_test_name,
+        geneticAncestry:
+          variant.joint!.freq_comparison_stats.stat_union.gen_ancs[0]?.toLowerCase() || undefined,
+        }
+      : {}
 
     return <QCFilter key={filter} filter={filter} data={data} />
   })


### PR DESCRIPTION
This PR is fixing mapping ancestry code to the ancestry label. Browser code requires the ancestry code to be a lower case string.